### PR TITLE
Added Vector3 dot product

### DIFF
--- a/source/monomyst/math/vector3.d
+++ b/source/monomyst/math/vector3.d
@@ -1,6 +1,7 @@
 module monomyst.math.vector3;
 
 import inteli.xmmintrin;
+import inteli.emmintrin;
 
 version (unittest) import monomyst.math.bassert;
 
@@ -49,7 +50,13 @@ struct Vector3
         // TODO: Package intel-intrinsics doesn't support this yet since this is SSE4.1
         // return _mm_cvtss_f32 (_mm_dp_ps (a.v, b.v, 0x71));
 
-        return a.x * b.x + a.y * b.y + a.z * b.z;
+        // return a.x * b.x + a.y * b.y + a.z * b.z;
+
+        __m128 v1 = _mm_loadu_ps (a.v.ptr);
+        __m128 v2 = _mm_loadu_ps (b.v.ptr);
+
+        __m128 res = _mm_mul_ps (v1, v2);
+        return res [0] + res [1] + res [2];
     }
 }
 

--- a/source/monomyst/math/vector3.d
+++ b/source/monomyst/math/vector3.d
@@ -1,11 +1,13 @@
 module monomyst.math.vector3;
 
-import core.simd;
+import inteli.xmmintrin;
+
+version (unittest) import monomyst.math.bassert;
 
 /// Vector3 struct
 struct Vector3
 {
-    private float [4] v;
+    package float [4] v;
 
     /// The X component of a vector
     @property float x () { return v [0]; }
@@ -35,6 +37,20 @@ struct Vector3
         Zero Vector3 (0, 0, 0)
     +/
     static Vector3 zero = Vector3 (0, 0, 0);
+
+    /++
+        Calculates a dot product of two vectors.
+        --------------------
+        (a.x * b.x) + (a.y * b.y) + (a.z * b.z)
+        --------------------
+    +/
+    static float dot (Vector3 a, Vector3 b)
+    {
+        // TODO: Package intel-intrinsics doesn't support this yet since this is SSE4.1
+        // return _mm_cvtss_f32 (_mm_dp_ps (a.v, b.v, 0x71));
+
+        return a.x * b.x + a.y * b.y + a.z * b.z;
+    }
 }
 
 unittest
@@ -45,4 +61,12 @@ unittest
 
     vector = Vector3 (43, 56, 13);
     assert (vector.x == 43 && vector.y == 56 && vector.z == 13);
+}
+
+unittest
+{
+    Vector3 a = Vector3 (2, 5, 3);
+    Vector3 b = Vector3 (7, 4, 9);
+    immutable float res = Vector3.dot (a, b);
+    bassert (res, 61);
 }


### PR DESCRIPTION
Issue number: #2 

Has partial SIMD support because the function needed `_mm_dp_ps` is SSE4.1. The package that's currently used [intel-intrinsics](https://github.com/AuburnSounds/intel-intrinsics) only has SSE1 and SSE2 support.
I know, very sad.